### PR TITLE
feat: display current mode in CropQ web console

### DIFF
--- a/MAVProxy/modules/mavproxy_cropq/local_server.py
+++ b/MAVProxy/modules/mavproxy_cropq/local_server.py
@@ -135,6 +135,9 @@ class LocalServer():
     def request_mpstatus(self):
         return json.loads(self.remote_self.mpstatus_to_json(self.remote_self.mpstate.status))
 
+    def request_mode(self):
+        return {"mode": self.remote_self.mpstate.status.flightmode}
+
     def request_log(self):
         return render_template('log.html')
 
@@ -158,6 +161,7 @@ class LocalServer():
         self.app.add_url_rule('/dataset', view_func=self.request_dataset, methods=['GET'])
         self.app.add_url_rule('/heartbeats', view_func=self.request_heartbeats, methods=['GET'])
         self.app.add_url_rule('/mpstatus', view_func=self.request_mpstatus, methods=['GET'])
+        self.app.add_url_rule('/mode', view_func=self.request_mode, methods=['GET'])
         self.app.add_url_rule('/config', view_func=self.request_config, methods=['GET'])
         self.app.add_url_rule('/log', view_func=self.request_log, methods=['GET'])
         self.app.add_url_rule('/log_data', view_func=self.request_log_data, methods=['GET'])

--- a/MAVProxy/modules/mavproxy_cropq/templates/console.html
+++ b/MAVProxy/modules/mavproxy_cropq/templates/console.html
@@ -4,7 +4,8 @@
 {{ super() }}
 {% endblock %}
 {% block content %}
-<nav class="navbar navbar-light bg-light">
+<nav class="navbar navbar-light bg-light flex-column align-items-start">
+    <span id="flightMode" class="navbar-text mb-2"></span>
     <form class="form-inline" action="/command" method="post">
         <input class="form-control mr-sm-2" type="text" placeholder="Command" aria-label="Command" name="command" id="command" value="command">
         <button class="btn btn-outline-success my-2 my-sm-0" type="submit">Submit</button>
@@ -29,6 +30,7 @@
 
 <script type="text/javascript" charset="utf-8">
     updateConsole();
+    updateMode();
 
     function updateConsole() {
         getData('/console_data').then((data) => {
@@ -54,6 +56,15 @@
             }
             setTimeout(() => {
                 updateConsole()
+            }, 1000)
+        })
+    }
+
+    function updateMode() {
+        getData('/mode').then((data) => {
+            document.getElementById("flightMode").innerHTML = data["mode"];
+            setTimeout(() => {
+                updateMode()
             }, 1000)
         })
     }


### PR DESCRIPTION
## Summary
- show vehicle flight mode above the CropQ console command input
- expose `/mode` endpoint to deliver current `mpstate.status.flightmode`

## Testing
- `python -m py_compile MAVProxy/modules/mavproxy_cropq/local_server.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ace4c95c84832bb38b3abf276cad9b